### PR TITLE
Reestruturação BasePage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vert-capital/template-front",
   "version": "v1.0.0",
   "scripts": {
-    "dev": "vite --mode development --port 8080 --host 0.0.0.0",
+    "dev": "vite --mode development --port 80 --host 0.0.0.0",
     "dev-st": "vite --mode staging --port 80",
     "build:ci": "vite build --mode ci",
     "build:stg": "vite build --mode staging",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@vert-capital/template-front",
   "version": "v1.0.0",
   "scripts": {
-    "dev": "vite --mode development --port 80 --host 0.0.0.0",
+    "dev": "vite --mode development --port 8080 --host 0.0.0.0",
     "dev-st": "vite --mode staging --port 80",
     "build:ci": "vite build --mode ci",
     "build:stg": "vite build --mode staging",

--- a/src/components/SideNav/SideNav.vue
+++ b/src/components/SideNav/SideNav.vue
@@ -61,13 +61,14 @@ export default defineComponent({
 </script>
 <style lang="scss">
 .v-sidenav {
-  height: 500px;
+  z-index: 3;
+  position: fixed;
+  top: 0;
+  bottom: 0;
   transition: all 0.3s ease;
   box-shadow: 1px 0 3px 0 #0000001a;
   background-color: $neutral-color-hight-pure;
   transition: all 0.3s ease;
-  height: auto;
-
   &--collapse {
     max-width: calc(var(--el-menu-icon-width) + var(--el-menu-base-level-padding) * 2);
   }
@@ -80,7 +81,7 @@ export default defineComponent({
     height: 3.75rem;
     box-sizing: border-box;
     width: auto;
-    transition: all 0.3s ease;
+    transition: all 0.3s ease-in-out;
     align-items: center;
     display: flex;
     justify-content: center;
@@ -88,8 +89,9 @@ export default defineComponent({
 
     > a > img {
       vertical-align: middle;
-      height: 1.5rem;
-      width: auto;
+      max-height: 2.25rem;
+      width: 100%;
+      transition: all 0.3s ease-in-out;
       max-width: 13rem;
     }
   }

--- a/src/components/TopNav/TopNav.vue
+++ b/src/components/TopNav/TopNav.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="v-topbar">
+  <div class="v-topbar" :class="{ 'v-topbar--closed': isCollapse }">
     <el-tooltip content="Menu" :show-after="500">
       <SvgIcon
         class="v-topbar--icon"
@@ -126,7 +126,15 @@ export default defineComponent({
   justify-content: space-between;
   top: 0;
   box-sizing: border-box;
-
+  position: fixed;
+  right: 0;
+  transition: all 0.3s ease;
+  width: calc(100% - 209px);
+  &--closed {
+    width: calc(
+      100% - 1px - calc(var(--el-menu-icon-width) + var(--el-menu-base-level-padding) * 2)
+    );
+  }
   &--icon {
     @extend %transition-link;
     color: $neutral-color-low-light;

--- a/src/pages/Base/BasePage.vue
+++ b/src/pages/Base/BasePage.vue
@@ -4,15 +4,15 @@
     <div class="v-body">
       <div>
         <top-nav v-model="isCollapse"></top-nav>
-        <el-scrollbar max-height="calc(100vh - 60px - 60px)">
-          <div class="v-main-content">
+        <div class="v-main" :class="{ 'v-main--closed': isCollapse }">
+          <div class="v-main--content">
             <slot>
               <router-view />
             </slot>
           </div>
-        </el-scrollbar>
+          <v-footer />
+        </div>
       </div>
-      <v-footer />
     </div>
   </el-container>
   <div class="v-basepage"></div>
@@ -78,7 +78,21 @@ export default defineComponent({
   flex-direction: column;
 }
 
-.v-main-content {
-  padding: 2rem;
+.v-main {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  box-sizing: border-box;
+  justify-content: space-between;
+  transition: all 0.3s ease;
+  padding-top: 60px;
+  padding-left: 208px;
+  background-color: #f2f2f2;
+  &--closed {
+    padding-left: calc(var(--el-menu-icon-width) + var(--el-menu-base-level-padding) * 2);
+  }
+  &--content {
+    padding: 2rem;
+  }
 }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@
     "@typescript-eslint/types" "5.36.1"
     eslint-visitor-keys "^3.3.0"
 
-"@vert-frame-core/design-system@latest":
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/@vert-frame-core/design-system/-/design-system-0.2.1.tgz#8a23e46e53a7bdea6b0b862627ed0d72dcca15f9"
-  integrity sha512-0MxHx9dSbL7YGfbWx0ieFWPt13OlwR77iALpTzyMGEqgNDTUF45syE7EYow13N5yF21sYS80EM5/T5z8BgXm+g==
+"@vert-frame-core/design-system@^0.3.1":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@vert-frame-core/design-system/-/design-system-0.3.2.tgz#fc1f7398b98e93365a8ec60cfc49af179f71f65f"
+  integrity sha512-neqnb6afhwPTq1hzpMuPCBatK2rmLj7ZInIgYNW1QLaQWMfW6FNNqWFK/hRVbWF6aOWOqX8i9YZmzkgQydC7Fg==
   dependencies:
     vue-demi "^0.12.1"
 


### PR DESCRIPTION
Foi gerado uma reestruturação deixando o TopNav fixo e desativando o footer fixo. A ideia é refatorar e manter o codigo atualizado e organizado para varios tipos de implementações.